### PR TITLE
Don't require java package naming conventions

### DIFF
--- a/src/main/scala/de/johoop/jacoco4sbt/DirectoriesSourceFileLocator.scala
+++ b/src/main/scala/de/johoop/jacoco4sbt/DirectoriesSourceFileLocator.scala
@@ -20,10 +20,11 @@ class DirectoriesSourceFileLocator(directories: Seq[File], sourceEncoding: Strin
     extends ISourceFileLocator {
   
   override def getSourceFile(packageName: String, fileName: String) = {
-    def findInDirectory(dir: File) = Option(dirSourceLocator(dir).getSourceFile(packageName, fileName))
+    def findInDirectory(dir: File, pkg: String) = Option(dirSourceLocator(dir).getSourceFile(pkg, fileName))
     def dirSourceLocator(dir: File) = new DirectorySourceFileLocator(dir, sourceEncoding, tabWidth)
-    
-    (directories flatMap findInDirectory).headOption getOrElse null
+    def findInRootOrPackageDirectory(dir: File) =
+      findInDirectory(dir, packageName) orElse findInDirectory(dir, "")
+    (directories flatMap findInRootOrPackageDirectory).headOption getOrElse null
   }
   
   override def getTabWidth = tabWidth


### PR DESCRIPTION
SBT does not enforce the java package naming convention for source
files (e.g. the source file Bar.scala for package com.meraki.foo would
be found in $TOPDIR/src/main/scala/com/meraki/foo/Bar.scala). This,
however, is where the jacoco sbt plugin requries source file to be if it
is to include Bar.scala.html in the html output. To get around this
restriction, I now allow jacoco to look in the root source directory as
well as the package directory for the desired file.
