### PR TITLE
Publishing: use Maven style for the repository

### DIFF
--- a/publish.sbt
+++ b/publish.sbt
@@ -1,5 +1,3 @@
 publishTo := Some(Resolver.file("packages", file("/var/www/packages.meraki.com/maven")))
 
-publishMavenStyle := false
-
 publishArtifact in Test := false


### PR DESCRIPTION
SBT defaults to maven2 style of repository for downloading plugins, so for ease
of compatibility between publishing and downloading we should switch to using
MavenStyle.
